### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wealthsimple/developer-tools
+* @wealthsimple/backend-platform


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

backend-platform should be pinged for PRs in this repo, not developer-tools (because that also pings FEPLAT)

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

This PR updates codeowners from developer-tools to backend-platform
